### PR TITLE
Update plink params

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -86,6 +86,8 @@ void dataset::load(const softpar & par)
 
 			std::ostringstream cmd;
 			cmd << par.plink << " --bfile " << par.ref_file[i] << \
+                    " --threads " << par.nthreads << \
+                    " --memory " << par.plink_mem << \
 					" --keep-allele-order --chr " << par.chr << \
 					" --extract " << par.ld_file[i] << ".snp --maf " << \
 					par.maf << " --make-bed --out " << par.ld_file[i] << "_ref";
@@ -93,12 +95,16 @@ void dataset::load(const softpar & par)
 
 			cmd.str("");
 			cmd << par.plink << " --bfile " << par.ld_file[i] << \
-					"_ref --keep-allele-order --r square bin4 --out " << par.ld_file[i];
+					"_ref --keep-allele-order --r square bin4 --out " << par.ld_file[i] << \
+                    " --threads " << par.nthreads << \
+                    " --memory " << par.plink_mem;
 			system(cmd.str().c_str());
 
 			cmd.str("");
 			cmd << par.plink << " --bfile " << par.ld_file[i] << \
-					"_ref --keep-allele-order --freq --out " << par.ld_file[i] + "_frq";
+					"_ref --keep-allele-order --freq --out " << par.ld_file[i] + "_frq" << \
+                    " --threads " << par.nthreads << \
+                    " --memory " << par.plink_mem;
 			system(cmd.str().c_str());
 			cmd.str("");
 			cmd << "rm " << par.ld_file[i] << ".snp";

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -24,7 +24,7 @@ public:
 	softpar() : out_dir(""), out_name(""), chr(""), start(0), end(0), plink(""), \
 	keep_ambig(false), mult_step(false), precmp(false), maf(0.005), level(0.95), \
 	min_purity(0.5), pth(1e-5), tol(1e-4), n_sig(5), max_iter(100), nthreads(1), \
-	key_by(2) {}
+	plink_mem(5000), key_by(2) {}
 
 	void split_str(const std::string& info, const std::string& label)
 	{
@@ -167,6 +167,7 @@ public:
 		std::cout << "--n_sig = " << n_sig << std::endl;
 		std::cout << "--max_iter = " << max_iter << std::endl;
 		std::cout << "--threads = " << nthreads << std::endl;
+		std::cout << "--plink_mem= " << plink_mem << std::endl;
 
 	}
 
@@ -179,7 +180,7 @@ public:
 	std::string plink;
 	bool keep_ambig, mult_step, precmp;
 	double maf, level, min_purity, pth, tol;
-	int n_sig, max_iter, nthreads;
+	int n_sig, max_iter, nthreads, plink_mem;
 
 	/*
 	 * 0 rsID, 1 position ref / alt, 2 position + rsID

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@ static struct option susiexOption[] =
 	{"max_iter",		required_argument,	NULL,	'I'},
 	{"tol",				required_argument,	NULL,	't'},
 	{"threads",			required_argument,	NULL,	'X'},
+	{"plink_mem",		required_argument,	NULL,	'K'},
 	{"help",			no_argument,		NULL,	'h'},
 };
 
@@ -80,6 +81,7 @@ void susiexHelp()
 	std::cout << "\t--max_iter      /  -I       MAXIMUM_ITERATIONS (optional): Maximum number of iterations allowed for the model fitting algorithm. Default is 100." << std::endl;
 	std::cout << "\t--tol           /  -t       TOLERANCE (optional): Tolerance for the convergence of the variational algorithm. Default is 1e-04." << std::endl;
 	std::cout << "\t--threads       /  -X       N_THREADS (optional): Number of threads for computation. Default is 1." << std::endl;
+	std::cout << "\t--plink_mem     /  -K       Maximum memory in MB used by PLINK. Default is 5000" << std::endl;
 	std::cout << "\t--help          /  -h       Print this help." << std::endl;
 	exit(0);
 }
@@ -89,7 +91,7 @@ int main(int argc, char **argv)
 	softpar par;
 	if(argc <= 1)
 		susiexHelp();
-	char optstring[] = "s:n:r:l:d:o:c:b:C:S:P:A:B:E:T:V:p:k:m:i:L:u:M:a:I:t:X:h";
+	char optstring[] = "s:n:r:l:d:o:c:b:C:S:P:A:B:E:T:V:p:k:m:i:L:u:M:a:I:t:X:K:h";
 	char opt;
 	std::map<std::string, bool> str2bool;
 	str2bool["True"] = true;
@@ -150,6 +152,7 @@ int main(int argc, char **argv)
 			case 'I': par.max_iter = atol(optarg); break;
 			case 't': par.tol = atof(optarg); break;
 			case 'X': par.nthreads = atol(optarg); break;
+			case 'K': par.plink_mem = atol(optarg); break;
 			case 'h': susiexHelp(); break;
 			case '?': std::cout << "Cannot identify parameter " << opt << std::endl;
 						susiexHelp();


### PR DESCRIPTION
Update parameters passed to Plink

The current implementation of calling Plink to calculate LD does not allow for changing the number of threads or memory used by Plink. This can lead to problems when running on high performance computing (HPC) clusters which require limits on the memory and cores used by a particular job.

This pull request updates the Plink LD calculations by:

* Pass number of threads available to SuSiEx
* Add `plink_mem` parameter to limit memory used by Plink.